### PR TITLE
Changes for 4.4.0 and later - LDAPImport has been cored

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -1,5 +1,5 @@
 ---
-abstract: 'RT-Extension-LDAPImport-MultiEmail Extension'
+abstract: 'RT-LDAPImport-MultiEmail Extension'
 author:
   - 'Best Practical Solutions, LLC <modules@bestpractical.com>'
 build_requires:
@@ -13,20 +13,18 @@ license: gpl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
   version: 1.4
-name: RT-Extension-LDAPImport-MultiEmail
+name: RT-LDAPImport-MultiEmail
 no_index:
   directory:
     - inc
     - t
 requires:
-  RT::Extension::LDAPImport: 0
   RT::Extension::MergeUsers: 0
   perl: 5.8.3
 resources:
   license: http://opensource.org/licenses/gpl-license.php
-version: '0.04'
-x_module_install_rtx_version: '0.36'
-x_requires_rt: 4.0.0
+version: '0.05'
+x_module_install_rtx_version: 0.34_04
+x_requires_rt: 4.4.0
 x_requires_rt_plugins:
-  - RT::Extension::LDAPImport
   - RT::Extension::MergeUsers

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,6 @@ use inc::Module::Install;
 
 RTx 'RT-Extension-LDAPImport-MultiEmail';
 
-requires_rt_plugin "RT::Extension::LDAPImport";
 requires_rt_plugin "RT::Extension::MergeUsers";
 
 require File::Basename;

--- a/README
+++ b/README
@@ -8,17 +8,9 @@ INSTALLATION
     make install
         May need root permissions
 
-    Edit your /opt/rt4/etc/RT_SiteConfig.pm
-        If you are using RT 4.2 or greater, add this line:
+    Edit your /opt/rt4/etc/RT_SiteConfig.pm and add this line:
 
             Plugin('RT::Extension::LDAPImport::MultiEmail');
-
-        For RT 4.0, add this line:
-
-            Set(@Plugins, qw(RT::Extension::LDAPImport::MultiEmail));
-
-        or add RT::Extension::LDAPImport::MultiEmail to your existing
-        @Plugins line.
 
         You will also need to specify which attribute contains "alternate"
         email addresses, via:

--- a/inc/Module/Install/RTx.pm
+++ b/inc/Module/Install/RTx.pm
@@ -8,7 +8,7 @@ no warnings 'once';
 
 use Module::Install::Base;
 use base 'Module::Install::Base';
-our $VERSION = '0.36';
+our $VERSION = '0.34_04';
 
 use FindBin;
 use File::Glob     ();
@@ -18,8 +18,7 @@ my @DIRS = qw(etc lib html static bin sbin po var);
 my @INDEX_DIRS = qw(lib bin sbin);
 
 sub RTx {
-    my ( $self, $name, $extra_args ) = @_;
-    $extra_args ||= {};
+    my ( $self, $name ) = @_;
 
     # Set up names
     my $fname = $name;
@@ -31,16 +30,12 @@ sub RTx {
         unless $self->version;
     $self->abstract("$name Extension")
         unless $self->abstract;
-    unless ( $extra_args->{no_readme_generation} ) {
-        $self->readme_from( "lib/$fname.pm",
-                            { options => [ quotes => "none" ] } );
-    }
+    $self->readme_from( "lib/$fname.pm",
+                        { options => [ quotes => "none" ] } );
     $self->add_metadata("x_module_install_rtx_version", $VERSION );
 
     # Try to find RT.pm
-    my @prefixes = qw( /opt /usr/local /home /usr /sw /usr/share/request-tracker4);
-    $ENV{RTHOME} =~ s{/RT\.pm$}{} if defined $ENV{RTHOME};
-    $ENV{RTHOME} =~ s{/lib/?$}{}  if defined $ENV{RTHOME};
+    my @prefixes = qw( /opt /usr/local /home /usr /sw );
     my @try = $ENV{RTHOME} ? ($ENV{RTHOME}, "$ENV{RTHOME}/lib") : ();
     while (1) {
         my @look = @INC;
@@ -51,10 +46,9 @@ sub RTx {
 
         warn
             "Cannot find the location of RT.pm that defines \$RT::LocalPath in: @look\n";
-        my $given = $self->prompt("Path to directory containing your RT.pm:") or exit;
-        $given =~ s{/RT\.pm$}{};
-        $given =~ s{/lib/?$}{};
-        @try = ($given, "$given/lib");
+        $_ = $self->prompt("Path to directory containing your RT.pm:") or exit;
+        $_ =~ s{(/lib)?/RT\.pm$}{};
+        @try = ("$_/rt4/lib", "$_/lib/rt4", "$_/lib");
     }
 
     print "Using RT configuration from $INC{'RT.pm'}:\n";
@@ -65,9 +59,7 @@ sub RTx {
     unshift @INC, $lib_path;
 
     # Set a baseline minimum version
-    unless ( $extra_args->{deprecated_rt} ) {
-        $self->requires_rt('4.0.0');
-    }
+    $self->requires_rt('4.0.0');
 
     # Installation locations
     my %path;
@@ -198,7 +190,7 @@ sub requires_rt_plugin {
     my ( $plugin ) = @_;
 
     if ($self->is_admin) {
-        my $plugins = $self->Meta->{values}{"x_requires_rt_plugins"} || [];
+        my $plugins = $self->{values}{"x_requires_rt_plugins"} || [];
         push @{$plugins}, $plugin;
         $self->add_metadata("x_requires_rt_plugins", $plugins);
     }
@@ -258,4 +250,4 @@ sub _load_rt_handle {
 
 __END__
 
-#line 390
+#line 369

--- a/lib/RT/Extension/LDAPImport/MultiEmail.pm
+++ b/lib/RT/Extension/LDAPImport/MultiEmail.pm
@@ -1,13 +1,13 @@
 use strict;
 use warnings;
-package RT::Extension::LDAPImport::MultiEmail;
+package RT::LDAPImport::MultiEmail;
 
-our $VERSION = '0.04';
+our $VERSION = '0.10';
 
 {
     no warnings 'redefine';
-    require RT::Extension::LDAPImport;
-    package RT::Extension::LDAPImport;
+    require RT::LDAPImport;
+    package RT::LDAPImport;
     sub new { return bless {}, 'RT::Extension::LDAPImport::MultiEmail'; }
 }
 
@@ -40,7 +40,7 @@ sub _import_user {
         my ($attrname, $address) = @{$val};
         my ($parsed) = Email::Address->parse($address);
         unless ($parsed) {
-            $self->_debug("Skipping alternate address $address in $attrname of $email, as it is invalid");
+            $RT::Logger->debug("Skipping alternate address $address in $attrname of $email, as it is invalid");
             next;
         }
 
@@ -58,7 +58,7 @@ sub _import_user {
             if ($effective_id and $user->id != $effective_id->Content) {
                 my $other = RT::User->new( RT->SystemUser );
                 $other->Load( $effective_id->Content );
-                $self->_warn($user->EmailAddress." lists $address".
+                $RT::Logger->warning($user->EmailAddress." lists $address".
                              " in $attrname as a secondary, which is already merged into ".
                              $other->EmailAddress
                          );
@@ -135,15 +135,9 @@ May need root permissions
 
 =item Edit your F</opt/rt4/etc/RT_SiteConfig.pm>
 
-If you are using RT 4.2 or greater, add this line:
+If you are using RT 4.4 or greater, add this line:
 
     Plugin('RT::Extension::LDAPImport::MultiEmail');
-
-For RT 4.0, add this line:
-
-    Set(@Plugins, qw(RT::Extension::LDAPImport::MultiEmail));
-
-or add C<RT::Extension::LDAPImport::MultiEmail> to your existing C<@Plugins> line.
 
 You will also need to specify which attribute contains "alternate" email
 addresses, via:

--- a/t/user-import.t.in
+++ b/t/user-import.t.in
@@ -5,7 +5,7 @@ use lib qw(/opt/rt4/local/lib /opt/rt4/lib);
 
 use RT::Test
     testing => 'RT::Extension::LDAPImport::MultiEmail',
-    requires => ['RT::Extension::LDAPImport', 'RT::Extension::MergeUsers'],
+    requires => ['RT::LDAPImport', 'RT::Extension::MergeUsers'],
     tests => undef;
 eval { require Net::LDAP::Server::Test; 1; } or do {
     plan skip_all => 'Unable to test without Net::Server::LDAP::Test';
@@ -28,7 +28,7 @@ for my $cfname (qw/SomeCF/) {
 }
 
 my $importer = RT::Extension::LDAPImport->new;
-isa_ok($importer,'RT::Extension::LDAPImport');
+isa_ok($importer,'RT::LDAPImport');
 isa_ok($importer,'RT::Extension::LDAPImport::MultiEmail');
 $importer->screendebug(1) if ($ENV{TEST_VERBOSE});
 


### PR DESCRIPTION
Mostly minor changes for logging.
Bumped the version number to 0.10 and made it dependant on RT 4.4.0 and RT::LDAPImport rather than RT::Extension::LDAPImport.